### PR TITLE
bug in How to-generate NA: mainly change "which(idx.incomplete=1)" into "idx.incomplete"

### DIFF
--- a/static/how-to/generate/amputation.R
+++ b/static/how-to/generate/amputation.R
@@ -430,12 +430,12 @@ produce_MAR_MNAR <- function(data, mechanism, perc.missing, idx.incomplete, idx.
       
           
       #all the variables can be covariates
-      if(length(idx.covariates[,1])!=length(which(idx.incomplete==1))){
+      if(length(idx.covariates[,1]) != length(idx.incomplete)){
         
         if(length(idx.covariates[,1])==1 & length(idx.covariates[1,])==length(data[1,])){
-          idx.covariates <- matrix(rep(idx.covariates,times = length(which(idx.incomplete==1))), nrow = length(which(idx.incomplete==1)), byrow = TRUE)
+          idx.covariates <- matrix(rep(idx.covariates,times = length(idx.incomplete)), nrow = length(idx.incomplete), byrow = TRUE)
         }else{
-          idx.covariates <- matrix(rep(1,times = length(which(idx.incomplete==1))*length(data[1,])), nrow = length(which(idx.incomplete==1)), byrow = TRUE)
+          idx.covariates <- matrix(rep(1,times = length(idx.incomplete)*length(data[1,])), nrow = length(idx.incomplete), byrow = TRUE)
           if(mechanism=="MAR"){
             diag(idx.covariates) <- 0
           }
@@ -451,9 +451,9 @@ produce_MAR_MNAR <- function(data, mechanism, perc.missing, idx.incomplete, idx.
   
     
       #this matrix will be used to run mice
-      missingness.matrix <- matrix(rep(1, times=length(which(idx.incomplete==1))*length(data[1,])), nrow = length(which(idx.incomplete==1)))
+      missingness.matrix <- matrix(rep(1, times=length(data[1,])*length(data[1,])), nrow = length(data[1,]))
       
-      for (i in which(idx.incomplete==1)){
+      for (i in idx.incomplete){
         missingness.matrix[i,i] <- 0
       }
       
@@ -596,8 +596,8 @@ produce_MAR_MNAR <- function(data, mechanism, perc.missing, idx.incomplete, idx.
   
   
   not.missing <- as.matrix(not.missing)
-  for (i in seq_len(length(which(idx.incomplete==1)))){
-    temp <- mice::ampute(not.missing, patterns = missingness.matrix[i,], weights = weights.covariates[i,],prop = perc.missing, bycases = TRUE)$amp
+  for (i in idx.incomplete){
+    temp <- mice::ampute(not.missing, patterns = missingness.matrix[i,], weights = weights.covariates[which(i == idx.incomplete),],prop = perc.missing, bycases = TRUE)$amp
     data.incomp[,which(missingness.matrix[i,]==0)] <- temp[,which(missingness.matrix[i,]==0)]
     # need to handle categorical variables (revert the one_hot encoding)!
     idx_newNA <- pmax(idx_newNA, as.matrix(is.na(temp)))   


### PR DESCRIPTION
Dear Teresa Aleves de Sousa and Imke Mayer,
thanks for sharing your "How to" to simulate missings. I had a closer look at the R code and found some bugs. I hope I can express myself briefly and clearly. If you have any questions, please feel free to ask! I wasn't sure if I should open an Issue on GitHub or give you an Pull Request, hope this way is ok:
I think you changed the input parameter idx.incomplete from a vector of 0 and 1 to a vector with integers of the positon of the variable which should have missings. This change results in some problems in the function produce_MAR_MNAR.
I want to say, that I only checked the function for "sum(is.na(data) == 0" = TRUE and "is.null(weights.covariates)" = TRUE.
 - line 433, 435, 438, 456, 599: I think which(idx.incomplete==1) has to be changed into "idx.incomplete"
 - line 454: In my opinion there has to be created a matrix with nrows equal to the number of variables which can possible have missings
 - line 600: Adjust to the for-argument

I hope I am not misleading the function, the adaptions works for my own example dataset. If you are interested in example data I can give it to you. Basically the data are a numerical and a factor variable. If you try to ampute data for idx.incomplete = c(2) you'll the problem.